### PR TITLE
Update Stellarium to v0.20.0.1

### DIFF
--- a/Stellarium.json
+++ b/Stellarium.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://stellarium.org/",
-    "version": "0.19.3",
+    "version": "0.20.0",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Stellarium/stellarium/releases/download/v0.19.3/stellarium-0.19.3.1-win64.exe",
-            "hash": "sha1:874810f7ffbc4e1a3425cab0319cf62cd49d59bd"
+            "url": "https://github.com/Stellarium/stellarium/releases/download/v0.20.0/stellarium-0.20.0.1-win64.exe",
+            "hash": "sha1:f6c519e5503871f9bdc45e1b7bebb550796897ab"
         },
         "32bit": {
-            "url": "https://github.com/Stellarium/stellarium/releases/download/v0.19.3/stellarium-0.19.3.1-win32.exe",
-            "hash": "sha1:5ec8b84d937635ebb8803bef5eda4fd940050745"
+            "url": "https://github.com/Stellarium/stellarium/releases/download/v0.20.0/stellarium-0.20.0.1-win32.exe",
+            "hash": "sha1:9209ae863d46a4345c1bcad3116bdbd71e1965f4"
         }
     },
     "innosetup": true,


### PR DESCRIPTION
I have little experience with pull request's, so please do not kick much)

The only thing - I could not figure out automatic version updates, as they (stellarium) use 2 values at once: 0.20.0 and 0.20.0.1